### PR TITLE
Bugifx: Upgrade from pip to pip3

### DIFF
--- a/services/can_logger/Dockerfile
+++ b/services/can_logger/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 
 RUN apt-get -y update
 
-RUN apt-get install -y --no-install-recommends python-pip pkg-config
+RUN apt-get install -y --no-install-recommends python3-pip pkg-config
 
 #Activate virtualenv
 


### PR DESCRIPTION
Current Dockerfile fails to build new images, due that pip has been phased out. Changed script to install pip3 instead. 

_This does not change any base code of the logger._