### PR TITLE
Bugfix: Upgrade from pip to pip3

### DIFF
--- a/services/cell_logger/Dockerfile
+++ b/services/cell_logger/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 RUN apt-get -y update
 
 # Needed for building dbus-python
-RUN apt-get install -y --no-install-recommends python-pip pkg-config libdbus-1-dev libglib2.0-dev libdbus-glib-1-dev python3-dbus
+RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev libglib2.0-dev libdbus-glib-1-dev python3-dbus
 
 # Activate virtualenv
 RUN python -m venv /opt/venv


### PR DESCRIPTION
Current Dockerfile fails to build new images, due that pip has been phased out. Changed script to install pip3 instead.

This does not change any base code of the logger.