### PR TITLE
Change Prometheus prefix to be j1939 

### DIFF
--- a/.github/workflows/build-and-push-services.yml
+++ b/.github/workflows/build-and-push-services.yml
@@ -9,17 +9,17 @@ jobs:
     strategy:
       matrix:
         service:
-          - j1939_filter
-          - gps2tsdb
-          - gps_nats
-          - oada_upload
-          - cell_logger
-          - can_watchdog
-          - can_logger
-          - socketcand
-          - cand
+          #- j1939_filter
+          #- gps2tsdb
+          #- gps_nats
+          #- oada_upload
+          #- cell_logger
+          #- can_watchdog
+          #- can_logger
+          #- socketcand
+          #- cand
           - j1939d
-          - gps-exporter
+          #- gps-exporter
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-and-push-services.yml
+++ b/.github/workflows/build-and-push-services.yml
@@ -128,7 +128,7 @@ jobs:
             GIT_REF=${{ github.sha }}
           labels: |
             org.opencontainers.image.title=${{ matrix.service }}
-            org.opencontainers.image.description=An ISOBlue Avena Service
+            org.opencontainers.image.description=An Avena Service for ISOBlue
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.version=${{ steps.prepare.outputs.version }}

--- a/.github/workflows/build-and-push-services.yml
+++ b/.github/workflows/build-and-push-services.yml
@@ -9,14 +9,14 @@ jobs:
     strategy:
       matrix:
         service:
-          #- j1939_filter
-          #- gps2tsdb
-          #- gps_nats
-          #- oada_upload
-          #- cell_logger
-          #- can_watchdog
-          #- can_logger
-          #- socketcand
+          - j1939_filter
+          - gps2tsdb
+          - gps_nats
+          - oada_upload
+          - cell_logger
+          - can_watchdog
+          - can_logger
+          - socketcand
           #- cand
           - j1939d
           #- gps-exporter

--- a/services/cell_logger/Dockerfile
+++ b/services/cell_logger/Dockerfile
@@ -1,5 +1,5 @@
 # BUILDER
-FROM python:3.9.14-buster as builder
+FROM python:3 as builder
 
 WORKDIR /usr/src/app
 
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 RUN apt-get -y update
 
 # Needed for building dbus-python
-RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev libdbus-1-3 libglib2.0-dev libdbus-glib-1-dev python3-dbus dbus
+RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev libdbus-1-3 libglib2.0-dev libdbus-glib-1-dev python3-dbus dbus cmake
 
 # Activate virtualenv
 RUN python -m venv /opt/venv
@@ -22,7 +22,7 @@ RUN pip install -r requirements.txt
 
 
 # RUNTIME
-FROM python:3.9.14-buster as runtime
+FROM python:3 as runtime
 
 WORKDIR /usr/src/app
 

--- a/services/cell_logger/Dockerfile
+++ b/services/cell_logger/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 RUN apt-get -y update
 
 # Needed for building dbus-python
-RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev libglib2.0-dev libdbus-glib-1-dev python3-dbus
+RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev libglib2.0-dev libdbus-glib-1-dev python3-dbus dbus
 
 # Activate virtualenv
 RUN python -m venv /opt/venv

--- a/services/cell_logger/Dockerfile
+++ b/services/cell_logger/Dockerfile
@@ -1,5 +1,5 @@
 # BUILDER
-FROM python:3 as builder
+FROM python:3.9.14-buster as builder
 
 WORKDIR /usr/src/app
 
@@ -22,7 +22,7 @@ RUN pip install -r requirements.txt
 
 
 # RUNTIME
-FROM python:3 as runtime
+FROM python:3.9.14-buster as runtime
 
 WORKDIR /usr/src/app
 

--- a/services/cell_logger/Dockerfile
+++ b/services/cell_logger/Dockerfile
@@ -7,7 +7,14 @@ WORKDIR /usr/src/app
 RUN apt-get -y update
 
 # Needed for building dbus-python
-RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev libglib2.0-dev libdbus-glib-1-dev python3-dbus dbus
+RUN apt-get install -y --no-install-recommends python3-pip \
+                                               pkg-config \
+                                               libdbus-1-dev \
+                                               lib-dbus-1-3 \
+                                               libglib2.0-dev \
+                                               libdbus-glib-1-dev \
+                                               python3-dbus \
+                                               dbus
 
 # Activate virtualenv
 RUN python -m venv /opt/venv

--- a/services/cell_logger/Dockerfile
+++ b/services/cell_logger/Dockerfile
@@ -7,14 +7,7 @@ WORKDIR /usr/src/app
 RUN apt-get -y update
 
 # Needed for building dbus-python
-RUN apt-get install -y --no-install-recommends python3-pip \
-                                               pkg-config \
-                                               libdbus-1-dev \
-                                               lib-dbus-1-3 \
-                                               libglib2.0-dev \
-                                               libdbus-glib-1-dev \
-                                               python3-dbus \
-                                               dbus
+RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev libdbus-1-3 libglib2.0-dev libdbus-glib-1-dev python3-dbus dbus
 
 # Activate virtualenv
 RUN python -m venv /opt/venv

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -48,6 +48,7 @@ COPY --from=sources /app/vendor /app/vendor
 
 RUN cargo build --release --offline --target $(cat /rust_target.txt)
 RUN strip /app/target/$(cat /rust_target.txt)/release/j1939d
+RUN cp /app/target/$(cat /rust_target.txt)/release/j1939d .
 
 ######
 ### Runtime Stage
@@ -57,6 +58,6 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y libssl1.1
 
-COPY --from=builder /app/target/$(cat /rust_target.txt)/release/j1939d .
+COPY --from=builder /app/j1939d .
 
 ENTRYPOINT [ "./j1939d" ]

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -57,6 +57,6 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y libssl1.1
 
-COPY --from=builder /app/target/release/j1939d .
+COPY --from=builder /app/target/$(cat /rust_target.txt)/release/j1939d .
 
 ENTRYPOINT [ "./j1939d" ]

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -47,7 +47,7 @@ COPY --from=sources /app/.cargo /app/.cargo
 COPY --from=sources /app/vendor /app/vendor
 
 RUN cargo build --release --offline --target $(cat /rust_target.txt)
-RUN strip /app/target/release/j1939d
+RUN strip /app/target/$(cat /rust_target)/release/j1939d
 
 ######
 ### Runtime Stage

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -13,9 +13,9 @@ COPY ./Cargo.lock .
 RUN mkdir -p /app/.cargo && cargo vendor /app/vendor > /app/.cargo/config
 
 #####
-## Build Stage 
+## Cross build Stage 
 #####
-FROM --platform=$BUILDPLATFORM rust:buster AS builder
+FROM --platform=$BUILDPLATFORM rust:buster AS cross-builder
 
 WORKDIR /app
 
@@ -58,8 +58,17 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
 
 #RUN cross build --release --offline --target $(cat /rust_target.txt)
 RUN cargo build --release --offline --target $(cat /rust_target.txt)
-RUN strip /app/target/$(cat /rust_target.txt)/release/j1939d
 RUN cp /app/target/$(cat /rust_target.txt)/release/j1939d .
+
+######
+## Post-build Stage
+######
+FROM rust:buster AS post-builder
+WORKDIR /app
+
+COPY --from=cross-builder /app/j1939d . 
+
+RUN strip j1939d
 
 ######
 ### Runtime Stage
@@ -69,6 +78,6 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y libssl1.1
 
-COPY --from=builder /app/j1939d .
+COPY --from=post-builder /app/j1939d .
 
 ENTRYPOINT [ "./j1939d" ]

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -30,15 +30,15 @@ RUN case "$TARGETPLATFORM" in \
     esac
 
 ## Install dependencies for both targets
-RUN cargo install cross --git https://github.com/cross-rs/cross
-#RUN apt-get update && apt-get upgrade -y
-#RUN apt-get install -y g++-arm-linux-gnueabihf \
-#                       g++-aarch64-linux-gnu \
-#                       libc6-dev-armhf-cross \
-#                       libc6-dev-arm64-cross
+#RUN cargo install cross --git https://github.com/cross-rs/cross
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y g++-arm-linux-gnueabihf \
+                       g++-aarch64-linux-gnu \
+                       libc6-dev-armhf-cross \
+                       libc6-dev-arm64-cross
                        
-#RUN rustup target add $(cat /rust_target.txt)
-#RUN rustup toolchain install stable-$(cat /rust_target.txt)
+RUN rustup target add $(cat /rust_target.txt)
+RUN rustup toolchain install stable-$(cat /rust_target.txt)
 
 ENV USER=1000
 
@@ -48,8 +48,16 @@ COPY ./src /app/src
 COPY --from=sources /app/.cargo /app/.cargo
 COPY --from=sources /app/vendor /app/vendor
 
-RUN cross build --release --offline --target $(cat /rust_target.txt)
-#RUN cargo build --release --offline --target $(cat /rust_target.txt)
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+    CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+
+#RUN cross build --release --offline --target $(cat /rust_target.txt)
+RUN cargo build --release --offline --target $(cat /rust_target.txt)
 RUN strip /app/target/$(cat /rust_target.txt)/release/j1939d
 RUN cp /app/target/$(cat /rust_target.txt)/release/j1939d .
 

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -47,7 +47,7 @@ COPY --from=sources /app/.cargo /app/.cargo
 COPY --from=sources /app/vendor /app/vendor
 
 RUN cargo build --release --offline --target $(cat /rust_target.txt)
-RUN strip /app/target/$(cat /rust_target)/release/j1939d
+RUN strip /app/target/$(cat /rust_target.txt)/release/j1939d
 
 ######
 ### Runtime Stage

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -1,7 +1,7 @@
 #####
 ## Source Stage
 #####
-FROM --platform=$BUILDPLATFORM rust:buster as sources
+FROM --platform=$BUILDPLATFORM rust:buster AS sources
 WORKDIR /app
 
 ENV USER=1000
@@ -13,10 +13,30 @@ COPY ./Cargo.lock .
 RUN mkdir -p /app/.cargo && cargo vendor /app/vendor > /app/.cargo/config
 
 #####
-## Build Stage
+## Build Stage 
 #####
-FROM rust:buster as builder
+FROM --platform=$BUILDPLATFORM rust:buster AS builder
+
 WORKDIR /app
+
+ARG TARGETPLATFORM
+
+## Select the right target for cross-compilation
+RUN case "$TARGETPLATFORM" in \
+      "linux/arm/v7") echo armv7-unknown-linux-gnueabihf > /rust_target.txt ;; \
+      "linux/arm64") echo aarch64-unknown-linux-gnu > /rust_target.txt ;; \
+      "linux/amd64") echo x86_64-unknown-linux-gnu > /rust_target.txt ;; \
+      *) exit 1 ;; \
+    esac
+
+## Install dependencies for both targets
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y g++-arm-linux-gnueabihf \
+                       g++-aarch64-linux-gnu \
+                       libc6-dev-armhf-cross \
+                       libc6-dev-arm64-cross
+                       
+RUN rustup target add $(cat /rust_target.txt)
 
 ENV USER=1000
 
@@ -26,7 +46,7 @@ COPY ./src /app/src
 COPY --from=sources /app/.cargo /app/.cargo
 COPY --from=sources /app/vendor /app/vendor
 
-RUN cargo build --release --offline
+RUN cargo build --release --offline --target $(cat /rust_target.txt)
 RUN strip /app/target/release/j1939d
 
 ######

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -30,14 +30,15 @@ RUN case "$TARGETPLATFORM" in \
     esac
 
 ## Install dependencies for both targets
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y g++-arm-linux-gnueabihf \
-                       g++-aarch64-linux-gnu \
-                       libc6-dev-armhf-cross \
-                       libc6-dev-arm64-cross
+RUN cargo install cross --git https://github.com/cross-rs/cross
+#RUN apt-get update && apt-get upgrade -y
+#RUN apt-get install -y g++-arm-linux-gnueabihf \
+#                       g++-aarch64-linux-gnu \
+#                       libc6-dev-armhf-cross \
+#                       libc6-dev-arm64-cross
                        
-RUN rustup target add $(cat /rust_target.txt)
-RUN rustup toolchain install stable-$(cat /rust_target.txt)
+#RUN rustup target add $(cat /rust_target.txt)
+#RUN rustup toolchain install stable-$(cat /rust_target.txt)
 
 ENV USER=1000
 
@@ -47,7 +48,8 @@ COPY ./src /app/src
 COPY --from=sources /app/.cargo /app/.cargo
 COPY --from=sources /app/vendor /app/vendor
 
-RUN cargo build --release --offline --target $(cat /rust_target.txt)
+RUN cross build --release --offline --target $(cat /rust_target.txt)
+#RUN cargo build --release --offline --target $(cat /rust_target.txt)
 RUN strip /app/target/$(cat /rust_target.txt)/release/j1939d
 RUN cp /app/target/$(cat /rust_target.txt)/release/j1939d .
 

--- a/services/j1939d/Dockerfile
+++ b/services/j1939d/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get install -y g++-arm-linux-gnueabihf \
                        libc6-dev-arm64-cross
                        
 RUN rustup target add $(cat /rust_target.txt)
+RUN rustup toolchain install stable-$(cat /rust_target.txt)
 
 ENV USER=1000
 

--- a/services/j1939d/src/main.rs
+++ b/services/j1939d/src/main.rs
@@ -171,7 +171,7 @@ fn main() -> Result<()> {
                     // TODO: Figure out these clones
                     let gauge = gauges.entry(spn.name.clone()).or_insert_with(|| {
                         let opts = opts!(
-                            format!("{}_{}", nats_sub_prefix, s),
+                            format!("{}_{}", "j1939", s),
                             spn.description.clone()
                         );
                         register_gauge!(opts).unwrap()


### PR DESCRIPTION
This PR changes the Prometheus prefix to be 'j1939', instead of being customizable by the NATS_SUB environment variable. This is due to Prometheus being not compatible with NATS subject semantics, especially with the topic separation characters (aka dots)