### PR TITLE
avena-video service

### DIFF
--- a/services/avena_video/Dockerfile
+++ b/services/avena_video/Dockerfile
@@ -1,0 +1,38 @@
+# BUILDER
+FROM python:3.11.3-slim-bullseye as builder
+
+WORKDIR /usr/src/app
+
+# Activate virtualenv
+RUN python -m venv /opt/venv
+
+# Make sure we use the virtualenv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy requirements and build with pip
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+
+
+# RUNTIME
+FROM python:3.11.3-slim-bullseye as runtime
+
+WORKDIR /usr/src/app
+
+# Update apt cache
+
+RUN apt-get -y update
+
+# Install FFmpeg and all its dependencies
+
+RUN apt-get install -y --no-install-recommends ffmpeg
+
+# Copy compiled venv from builder
+COPY --from=builder /opt/venv /opt/venv
+
+# Make sure we use the virtualenv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY avena_video.py .
+CMD [ "python", "./avena_video.py" ]

--- a/services/avena_video/avena_video.py
+++ b/services/avena_video/avena_video.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python3
+
+import asyncio
+import nats
+import os
+import json
+from functools import partial
+from datetime import datetime
+from ffmpeg import Progress, FFmpegError
+from ffmpeg.asyncio import FFmpeg
+
+async def main():
+    
+    ## Connect to NATS server running in localhost
+    nc = await nats.connect("nats://localhost:4222")
+    
+    rtsp_url = f"rtsp://{os.getenv('RTSP_USER')}:{os.getenv('RTSP_PASSWORD')}@@{os.getenv('CAMERA_IP')}:{os.getenv('RTSP_PORT')}/s1"
+    rtp_url = f"rtp://{os.getenv('RTP_ENDPOINT')}:{os.getenv('RTP_PORT')}/{os.getenv('AVENA_PREFIX')}-{os.getenv('CAMERA')}"
+    
+    ## Specify ffmpeg options to convert an RTSP stream to a RTP stream
+    stream = (
+        FFmpeg()
+        .option("copyts")
+        .option("fflags", value="nobuffer")
+        #.option("vcodec", value="copy")
+        .option("movflags", value="frag_keyframe+empty_moov")
+        .input(rtsp_url, rtsp_transport="tcp")
+        .output(rtp_url)
+    )
+
+    ## Print initialization messages
+    @stream.on("start")
+    def on_start(arguments: list[str]):
+        print("Starting FFmpeg...")
+
+    ## Print error messages
+    @stream.on("stderr")
+    def on_stderr(line):
+        print(line)
+
+    ## Print current progress
+    @stream.on("progress")
+    def on_progress(progress: Progress):
+        print(progress)
+
+    @stream.on("terminated")
+    def on_terminated():
+        print(f"FFmpeg terminated succesfully")
+
+    ## Toggle RTSP stream via req-reply NATS messages
+    async def toggle_stream(stream, msg):
+
+        reply = {}
+        request = json.loads(msg.data.decode())
+        cmd = request['command']
+
+        reply["time"] = datetime.now().isoformat()
+        reply["command"] = cmd
+        reply["camera"] = os.getenv('CAMERA')
+
+        if cmd == "start":
+    
+            ## Start FFmpeg with the options above
+
+            try:
+                #asyncio.create_task(stream.execute(), name="video-stream")
+                task = asyncio.gather(stream.execute(), return_exceptions=False)
+            ## FIX-ME: Handle error appropriately. Exceptions from future are not being
+            ## handled
+            except(FFmpegError):
+                print(f"Failed to start {os.getenv('CAMERA')} video stream")
+                reply["status"] = "fail"
+            
+            
+            reply["status"] = "ok"
+
+        elif cmd == "stop":
+            
+            print("Stopping video stream...")
+            try:
+                stream.terminate()
+                reply["status"] = "ok"
+
+            except(FFmpegError):
+                print("No stream to stop. Doing nothing...")
+                reply["status"] = "fail"
+
+        else:
+            reply["status"] = "fail"
+            print('Invalid command received. Doing nothing...')
+        
+        reply = json.dumps(reply)
+        await nc.publish(msg.reply, bytes(reply, "utf-8"))
+
+    # Use queue named 'stream' for distributing requests
+    # among subscribers.
+    subject = f"{os.getenv('AVENA_PREFIX')}.video.{os.getenv('CAMERA')}.control" 
+    sub = await nc.subscribe(subject=subject, queue="stream", cb=partial(toggle_stream, stream))
+    
+
+if __name__ == '__main__':
+    
+    loop = asyncio.get_event_loop()
+    asyncio.ensure_future(main())
+    try:
+        loop.run_forever()
+    except(KeyboardInterrupt):
+        print("Ctrl+C detected. Terminating...")
+        quit()
+    loop.close()
+

--- a/services/avena_video/requirements.txt
+++ b/services/avena_video/requirements.txt
@@ -1,0 +1,2 @@
+python-ffmpeg==2.0.4
+nats-py==2.2.0


### PR DESCRIPTION
This PR adds an RTSP streaming service for streaming video from IP cameras by calling ffmpeg using the `python-ffmpeg` binding. This service implements a video stream that can be controlled with a NATS request, where the service replies with the status of the request.

TODO: 

- Exception handling after getting an error when starting a ffmpeg thread (properly report error status over NATS)